### PR TITLE
JMK_49: get mapping for all the open job_postings

### DIFF
--- a/src/main/java/com/jobmatrix/controller/JobPostingController.java
+++ b/src/main/java/com/jobmatrix/controller/JobPostingController.java
@@ -25,9 +25,9 @@ public class JobPostingController {
         return new ResponseEntity<>(createdJobPosting, HttpStatus.CREATED);
     }
 
-    @GetMapping("/{jobPostingId}")
+    @GetMapping("/open_job_postings")
     public ResponseEntity<List<JobPosting>> getOpenJobPostings() {
-        List<JobPosting> openJobPostings = (List<JobPosting>) jobPostingService.getOpenJobPostings();
+        List<JobPosting> openJobPostings = jobPostingService.getOpenJobPostings();
         return ResponseEntity.ok(openJobPostings);
     }
 } 

--- a/src/main/java/com/jobmatrix/controller/JobPostingController.java
+++ b/src/main/java/com/jobmatrix/controller/JobPostingController.java
@@ -9,6 +9,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/v1/job_postings")
 @Tag(name = "Job Posting ", description = "Operations related to job posting ")
@@ -21,5 +23,11 @@ public class JobPostingController {
     public ResponseEntity<JobPosting> createJobPosting(@RequestBody JobPostingDTO jobPostingDTO) {
         JobPosting createdJobPosting = jobPostingService.createJobPosting(jobPostingDTO);
         return new ResponseEntity<>(createdJobPosting, HttpStatus.CREATED);
+    }
+
+    @GetMapping("/{jobPostingId}")
+    public ResponseEntity<List<JobPosting>> getOpenJobPostings() {
+        List<JobPosting> openJobPostings = (List<JobPosting>) jobPostingService.getOpenJobPostings();
+        return ResponseEntity.ok(openJobPostings);
     }
 } 

--- a/src/main/java/com/jobmatrix/repository/JobPostingRepository.java
+++ b/src/main/java/com/jobmatrix/repository/JobPostingRepository.java
@@ -1,9 +1,13 @@
 package com.jobmatrix.repository;
 
 import com.jobmatrix.entity.JobPosting;
+import com.jobmatrix.entity.JobPostingStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface JobPostingRepository extends JpaRepository<JobPosting, Long> {
+    List<JobPosting> findByJobPostingStatus(JobPostingStatus jobPostingStatus);
 } 

--- a/src/main/java/com/jobmatrix/service/JobPostingService.java
+++ b/src/main/java/com/jobmatrix/service/JobPostingService.java
@@ -3,6 +3,9 @@ package com.jobmatrix.service;
 import com.jobmatrix.dto.JobPostingDTO;
 import com.jobmatrix.entity.JobPosting;
 
+import java.util.List;
+
 public interface JobPostingService {
     JobPosting createJobPosting(JobPostingDTO jobPostingDTO);
+    List<JobPosting> getOpenJobPostings();
 } 

--- a/src/main/java/com/jobmatrix/serviceimpl/JobPostingServiceImpl.java
+++ b/src/main/java/com/jobmatrix/serviceimpl/JobPostingServiceImpl.java
@@ -13,6 +13,8 @@ import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class JobPostingServiceImpl implements JobPostingService {
@@ -26,19 +28,21 @@ public class JobPostingServiceImpl implements JobPostingService {
     public JobPosting createJobPosting(JobPostingDTO jobPostingDTO) {
         // Map DTO to Entity
         JobPosting jobPosting = modelMapper.map(jobPostingDTO, JobPosting.class);
-
         // Ensure it's treated as a new entity
         jobPosting.setJobPostingId(null);
-
         // Set default job posting status
         jobPosting.setJobPostingStatus(JobPostingStatus.DRAFT);
-
         // Fetch category and set it
         Category category = categoryRepository.findById(jobPostingDTO.getCategoryId())
                 .orElseThrow(() -> new CategoryNotFoundException(jobPostingDTO.getCategoryId()));
         jobPosting.setCategory(category);
-
         // Save and return
         return jobPostingRepository.save(jobPosting);
+    }
+
+    @Override
+    public List<JobPosting> getOpenJobPostings() {
+        return jobPostingRepository.findByJobPostingStatus(JobPostingStatus.OPEN);
+
     }
 }

--- a/src/test/java/com/jobmatrix/controller/JobPostingControllerTest.java
+++ b/src/test/java/com/jobmatrix/controller/JobPostingControllerTest.java
@@ -15,6 +15,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
+import java.util.List;
 import java.util.UUID;
 
 @WebMvcTest(JobPostingController.class)
@@ -47,4 +48,22 @@ public class JobPostingControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.createdAt").exists())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.updatedAt").exists());
     }
+
+    @Test
+    void testGetOpenJobPostings() throws Exception {
+        UUID clientId = UUID.randomUUID();
+        List<JobPosting> mockJobPostings = List.of(
+                JobPostingTestDataFactory.createJobPostingEntity(clientId),
+                JobPostingTestDataFactory.createJobPostingEntity(clientId) // You can tweak for variation
+        );
+
+        Mockito.when(jobPostingService.getOpenJobPostings()).thenReturn(mockJobPostings);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/job_postings/open_job_postings"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.length()").value(2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].jobPostingId").value(1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].title").value("Sample Job"));
+    }
+
 }

--- a/src/test/java/com/jobmatrix/controller/JobPostingControllerTest.java
+++ b/src/test/java/com/jobmatrix/controller/JobPostingControllerTest.java
@@ -54,7 +54,7 @@ public class JobPostingControllerTest {
         UUID clientId = UUID.randomUUID();
         List<JobPosting> mockJobPostings = List.of(
                 JobPostingTestDataFactory.createJobPostingEntity(clientId),
-                JobPostingTestDataFactory.createJobPostingEntity(clientId) // You can tweak for variation
+                JobPostingTestDataFactory.createJobPostingEntity(clientId)
         );
 
         Mockito.when(jobPostingService.getOpenJobPostings()).thenReturn(mockJobPostings);

--- a/src/test/java/com/jobmatrix/service/JobPostingServiceImplTest.java
+++ b/src/test/java/com/jobmatrix/service/JobPostingServiceImplTest.java
@@ -18,6 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.modelmapper.ModelMapper;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -97,5 +98,39 @@ public class JobPostingServiceImplTest {
         verify(categoryRepository, times(1)).findById(jobPostingDTO.getCategoryId());
         verify(jobPostingRepository, times(1)).save(any(JobPosting.class));
         verify(modelMapper, times(1)).map(jobPostingDTO, JobPosting.class);
+    }
+
+
+    @Test
+    public void testGetOpenJobPostings_WhenSomeAreOpen() {
+        JobPosting openJob1 = JobPostingTestDataFactory.createJobPostingEntity(UUID.randomUUID());
+        JobPosting openJob2 = JobPostingTestDataFactory.createJobPostingEntity(UUID.randomUUID());
+
+        openJob1.setJobPostingStatus(JobPostingStatus.OPEN);
+        openJob2.setJobPostingStatus(JobPostingStatus.OPEN);
+
+        when(jobPostingRepository.findByJobPostingStatus(JobPostingStatus.OPEN))
+                .thenReturn(List.of(openJob1, openJob2));
+
+        List<JobPosting> result = jobPostingService.getOpenJobPostings();
+
+        assertNotNull(result);
+        assertEquals(2, result.size());
+        assertTrue(result.stream().allMatch(job -> job.getJobPostingStatus() == JobPostingStatus.OPEN));
+
+        verify(jobPostingRepository).findByJobPostingStatus(JobPostingStatus.OPEN);
+    }
+
+    @Test
+    public void testGetOpenJobPostings_WhenNoneAreOpen() {
+        when(jobPostingRepository.findByJobPostingStatus(JobPostingStatus.OPEN))
+                .thenReturn(List.of());
+
+        List<JobPosting> result = jobPostingService.getOpenJobPostings();
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+
+        verify(jobPostingRepository).findByJobPostingStatus(JobPostingStatus.OPEN);
     }
 }

--- a/src/test/java/com/jobmatrix/service/JobPostingServiceImplTest.java
+++ b/src/test/java/com/jobmatrix/service/JobPostingServiceImplTest.java
@@ -133,4 +133,35 @@ public class JobPostingServiceImplTest {
 
         verify(jobPostingRepository).findByJobPostingStatus(JobPostingStatus.OPEN);
     }
+
+    @Test
+    public void testGetOpenJobPostings_WithMultipleStatuses_ShouldReturnOnlyOpenJobs() {
+        JobPosting openJob1 = JobPostingTestDataFactory.createJobPostingEntity(UUID.randomUUID());
+        JobPosting openJob2 = JobPostingTestDataFactory.createJobPostingEntity(UUID.randomUUID());
+        JobPosting draftJob = JobPostingTestDataFactory.createJobPostingEntity(UUID.randomUUID());
+        JobPosting inReviewJob = JobPostingTestDataFactory.createJobPostingEntity(UUID.randomUUID());
+        JobPosting inProgressJob = JobPostingTestDataFactory.createJobPostingEntity(UUID.randomUUID());
+        JobPosting closedJob = JobPostingTestDataFactory.createJobPostingEntity(UUID.randomUUID());
+        JobPosting completedJob = JobPostingTestDataFactory.createJobPostingEntity(UUID.randomUUID());
+
+        openJob1.setJobPostingStatus(JobPostingStatus.OPEN);
+        openJob2.setJobPostingStatus(JobPostingStatus.OPEN);
+        draftJob.setJobPostingStatus(JobPostingStatus.DRAFT);
+        inReviewJob.setJobPostingStatus(JobPostingStatus.IN_REVIEW);
+        inProgressJob.setJobPostingStatus(JobPostingStatus.IN_PROGRESS);
+        closedJob.setJobPostingStatus(JobPostingStatus.CLOSED);
+        completedJob.setJobPostingStatus(JobPostingStatus.COMPLETED);
+
+        when(jobPostingRepository.findByJobPostingStatus(JobPostingStatus.OPEN))
+                .thenReturn(List.of(openJob1, openJob2));
+
+        List<JobPosting> result = jobPostingService.getOpenJobPostings();
+
+        assertNotNull(result);
+        assertEquals(2, result.size());
+        assertTrue(result.stream().allMatch(job -> job.getJobPostingStatus() == JobPostingStatus.OPEN));
+
+        verify(jobPostingRepository, times(1)).findByJobPostingStatus(JobPostingStatus.OPEN);
+    }
+
 }


### PR DESCRIPTION
This PR adds a new API endpoint in the Job Posting microservice that allows freelancers to fetch job postings with status OPEN. It queries the database for jobs marked as open and returns them as a list. 
**Endpoint Details:**
URL: `GET /api/v1/job_postings/open_job_postings`
Response: Returns a list of JobPosting entities with status OPEN, along with HTTP status 200 OK