### PR TITLE
JMK_50: get mapping to fetch jobPosting by its id

### DIFF
--- a/src/main/java/com/jobmatrix/controller/JobPostingController.java
+++ b/src/main/java/com/jobmatrix/controller/JobPostingController.java
@@ -10,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/v1/job_postings")
@@ -29,5 +30,11 @@ public class JobPostingController {
     public ResponseEntity<List<JobPosting>> getOpenJobPostings() {
         List<JobPosting> openJobPostings = jobPostingService.getOpenJobPostings();
         return ResponseEntity.ok(openJobPostings);
+    }
+
+    @GetMapping("/{jobPostingId}")
+    public ResponseEntity<JobPosting> getJobPostingById(@PathVariable Long jobPostingId){
+        JobPosting jobPosting = jobPostingService.getJobPostingById(jobPostingId);
+        return ResponseEntity.ok(jobPosting);
     }
 } 

--- a/src/main/java/com/jobmatrix/exceptionHandling/GlobalExceptionHandler.java
+++ b/src/main/java/com/jobmatrix/exceptionHandling/GlobalExceptionHandler.java
@@ -13,5 +13,9 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
     }
 
+    @ExceptionHandler(JobPostingNotFoundException.class)
+    public ResponseEntity<String> handleJobPostingNotFoundException(JobPostingNotFoundException ex){
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
+    }
     // You can add more @ExceptionHandler methods here for other custom exceptions
 }

--- a/src/main/java/com/jobmatrix/exceptionHandling/JobPostingNotFoundException.java
+++ b/src/main/java/com/jobmatrix/exceptionHandling/JobPostingNotFoundException.java
@@ -1,0 +1,7 @@
+package com.jobmatrix.exceptionHandling;
+
+public class JobPostingNotFoundException extends RuntimeException {
+  public JobPostingNotFoundException(Long jobPostingId) {
+    super("JobPosting not found at given jobPostingId: " + jobPostingId);
+  }
+}

--- a/src/main/java/com/jobmatrix/service/JobPostingService.java
+++ b/src/main/java/com/jobmatrix/service/JobPostingService.java
@@ -8,4 +8,5 @@ import java.util.List;
 public interface JobPostingService {
     JobPosting createJobPosting(JobPostingDTO jobPostingDTO);
     List<JobPosting> getOpenJobPostings();
+    JobPosting getJobPostingById(Long jobPostingId);
 } 

--- a/src/main/java/com/jobmatrix/serviceimpl/JobPostingServiceImpl.java
+++ b/src/main/java/com/jobmatrix/serviceimpl/JobPostingServiceImpl.java
@@ -5,6 +5,7 @@ import com.jobmatrix.entity.Category;
 import com.jobmatrix.entity.JobPosting;
 import com.jobmatrix.entity.JobPostingStatus;
 import com.jobmatrix.exceptionHandling.CategoryNotFoundException;
+import com.jobmatrix.exceptionHandling.JobPostingNotFoundException;
 import com.jobmatrix.repository.CategoryRepository;
 import com.jobmatrix.repository.JobPostingRepository;
 import com.jobmatrix.service.JobPostingService;
@@ -14,6 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -45,4 +47,12 @@ public class JobPostingServiceImpl implements JobPostingService {
         return jobPostingRepository.findByJobPostingStatus(JobPostingStatus.OPEN);
 
     }
+
+    @Override
+    public JobPosting getJobPostingById(Long jobPostingId) {
+
+        return jobPostingRepository.findById(jobPostingId)
+                .orElseThrow(() -> new JobPostingNotFoundException(jobPostingId));
+    }
+
 }

--- a/src/test/java/com/jobmatrix/controller/JobPostingControllerTest.java
+++ b/src/test/java/com/jobmatrix/controller/JobPostingControllerTest.java
@@ -66,4 +66,19 @@ public class JobPostingControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$[0].title").value("Sample Job"));
     }
 
+    @Test
+    void testGetJobPostingById() throws Exception {
+        UUID clientId = UUID.randomUUID();
+        long jobPostingId = 1L;
+
+        JobPosting mockJobPosting = JobPostingTestDataFactory.createJobPostingEntity(clientId);
+
+        Mockito.when(jobPostingService.getJobPostingById(jobPostingId)).thenReturn(mockJobPosting);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/job_postings/" + jobPostingId))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.jobPostingId").value(1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.title").value("Sample Job"));
+    }
+
 }

--- a/src/test/java/com/jobmatrix/exceptionHandling/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/jobmatrix/exceptionHandling/GlobalExceptionHandlerTest.java
@@ -21,6 +21,11 @@ class GlobalExceptionHandlerTest {
         public String throwCategoryNotFoundException() {
             throw new CategoryNotFoundException(5L); // Correct usage
         }
+
+        @GetMapping("/test-job-posting-not-found")
+        public String throwJobPostingNotFoundException() {
+            throw new JobPostingNotFoundException(7L);
+        }
     }
 
     @BeforeEach
@@ -37,4 +42,13 @@ class GlobalExceptionHandlerTest {
                 .andExpect(status().isNotFound())
                 .andExpect(content().string("Category not found at given categoryId: 5"));
     }
+
+    @Test
+    void handleJobPostingNotFound_ShouldReturnNotFoundWithMessage() throws Exception {
+        mockMvc.perform(get("/test-job-posting-not-found")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(content().string("JobPosting not found at given jobPostingId: 7"));
+    }
+
 }

--- a/src/test/java/com/jobmatrix/service/JobPostingServiceImplTest.java
+++ b/src/test/java/com/jobmatrix/service/JobPostingServiceImplTest.java
@@ -4,6 +4,7 @@ import com.jobmatrix.dto.JobPostingDTO;
 import com.jobmatrix.entity.Category;
 import com.jobmatrix.entity.JobPosting;
 import com.jobmatrix.entity.JobPostingStatus;
+import com.jobmatrix.exceptionHandling.JobPostingNotFoundException;
 import com.jobmatrix.repository.CategoryRepository;
 import com.jobmatrix.repository.JobPostingRepository;
 import com.jobmatrix.serviceimpl.JobPostingServiceImpl;
@@ -14,8 +15,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.modelmapper.ModelMapper;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -163,5 +167,45 @@ public class JobPostingServiceImplTest {
 
         verify(jobPostingRepository, times(1)).findByJobPostingStatus(JobPostingStatus.OPEN);
     }
+
+    @Test
+    void getJobPostingById_shouldReturnJobPostingEntity() {
+        long jobPostingId = 1L;
+        JobPosting mockJobPosting = JobPostingTestDataFactory.createJobPostingEntity(UUID.randomUUID());
+        mockJobPosting.setJobPostingId(jobPostingId);
+
+        when(jobPostingRepository.findById(jobPostingId)).thenReturn(Optional.of(mockJobPosting));
+
+        JobPosting result = jobPostingService.getJobPostingById(jobPostingId);
+
+        assertNotNull(result);
+        assertEquals(mockJobPosting.getJobPostingId(), result.getJobPostingId());
+        assertEquals(mockJobPosting.getTitle(), result.getTitle());
+        assertEquals(mockJobPosting.getDescription(), result.getDescription());
+        assertEquals(mockJobPosting.getBudgetType(), result.getBudgetType());
+        assertEquals(mockJobPosting.getHourlyMinRate(), result.getHourlyMinRate());
+        assertEquals(mockJobPosting.getHourlyMaxRate(), result.getHourlyMaxRate());
+        assertEquals(mockJobPosting.getProjectDuration(), result.getProjectDuration());
+        assertEquals(mockJobPosting.getExperienceLevel(), result.getExperienceLevel());
+
+        verify(jobPostingRepository, times(1)).findById(jobPostingId);
+    }
+
+    @Test
+    void getJobPostingById_shouldThrowJobPostingNotFoundException() {
+        long jobPostingId = 2L;
+
+        when(jobPostingRepository.findById(jobPostingId)).thenReturn(Optional.empty());
+
+        JobPostingNotFoundException exception = assertThrows(
+                JobPostingNotFoundException.class,
+                () -> jobPostingService.getJobPostingById(jobPostingId),
+                "JobPosting not found at given jobPostingId"
+        );
+
+        assertEquals("JobPosting not found at given jobPostingId: " + jobPostingId, exception.getMessage());
+        verify(jobPostingRepository, times(1)).findById(jobPostingId);
+    }
+
 
 }


### PR DESCRIPTION
This PR adds a new API endpoint in the Job Posting microservice that allows users to fetch a specific job posting by its ID. It queries the database for the job posting associated with the provided ID and returns its details if found. If the job posting does not exist, a JobPostingNotFoundException is thrown and handled globally, returning a 404 error.

**Endpoint Details:**
URL: GET /api/v1/job_postings/{id}
Path Variable: id – The unique identifier of the job posting to retrieve.
Response: Returns the JobPosting entity associated with the provided ID, along with HTTP status 200 OK. If not found, returns a 404 Not Found with an appropriate error message.