### PR TITLE
JMK_61: Expose an endpoint to GET all the job postings by a specific client_id

### DIFF
--- a/src/main/java/com/jobmatrix/JmJobPostingApplication.java
+++ b/src/main/java/com/jobmatrix/JmJobPostingApplication.java
@@ -3,7 +3,6 @@ package com.jobmatrix;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication
 @EntityScan(basePackages = {"com.common.entity", "com.jobmatrix.entity"})

--- a/src/main/java/com/jobmatrix/JmJobPostingApplication.java
+++ b/src/main/java/com/jobmatrix/JmJobPostingApplication.java
@@ -2,8 +2,11 @@ package com.jobmatrix;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication
+@EntityScan(basePackages = {"com.common.entity", "com.jobmatrix.entity"})
 public class JmJobPostingApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/jobmatrix/controller/JobPostingController.java
+++ b/src/main/java/com/jobmatrix/controller/JobPostingController.java
@@ -37,4 +37,10 @@ public class JobPostingController {
         JobPosting jobPosting = jobPostingService.getJobPostingById(jobPostingId);
         return ResponseEntity.ok(jobPosting);
     }
+
+    @GetMapping("/client/{clientId}")
+    public ResponseEntity<List<JobPosting>> getJobPostingsByClientId(@PathVariable UUID clientId) {
+        List<JobPosting> jobPostings = jobPostingService.getJobPostingsByClientId(clientId);
+        return ResponseEntity.ok(jobPostings);
+    }
 } 

--- a/src/main/java/com/jobmatrix/exceptionHandling/GlobalExceptionHandler.java
+++ b/src/main/java/com/jobmatrix/exceptionHandling/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.jobmatrix.exceptionHandling;
 
+import com.common.exceptionHandling.ClientNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -18,4 +19,14 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
     }
     // You can add more @ExceptionHandler methods here for other custom exceptions
+
+    @ExceptionHandler(ClientNotFoundException.class)
+    public ResponseEntity<String> handleClientNotFoundException(ClientNotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
+    }
+
+    @ExceptionHandler(JobPostingByClientIdNotFoundException.class)
+    public ResponseEntity<String> handleJobPostingByClientIdNotFoundException(JobPostingByClientIdNotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
+    }
 }

--- a/src/main/java/com/jobmatrix/exceptionHandling/GlobalExceptionHandler.java
+++ b/src/main/java/com/jobmatrix/exceptionHandling/GlobalExceptionHandler.java
@@ -25,8 +25,4 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
     }
 
-    @ExceptionHandler(JobPostingByClientIdNotFoundException.class)
-    public ResponseEntity<String> handleJobPostingByClientIdNotFoundException(JobPostingByClientIdNotFoundException ex) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
-    }
 }

--- a/src/main/java/com/jobmatrix/exceptionHandling/JobPostingByClientIdNotFoundException.java
+++ b/src/main/java/com/jobmatrix/exceptionHandling/JobPostingByClientIdNotFoundException.java
@@ -1,9 +1,0 @@
-package com.jobmatrix.exceptionHandling;
-
-import java.util.UUID;
-
-public class JobPostingByClientIdNotFoundException extends RuntimeException {
-  public JobPostingByClientIdNotFoundException(UUID clientId) {
-    super("No job postings found for client ID: " + clientId);
-  }
-}

--- a/src/main/java/com/jobmatrix/exceptionHandling/JobPostingByClientIdNotFoundException.java
+++ b/src/main/java/com/jobmatrix/exceptionHandling/JobPostingByClientIdNotFoundException.java
@@ -1,0 +1,9 @@
+package com.jobmatrix.exceptionHandling;
+
+import java.util.UUID;
+
+public class JobPostingByClientIdNotFoundException extends RuntimeException {
+  public JobPostingByClientIdNotFoundException(UUID clientId) {
+    super("No job postings found for client ID: " + clientId);
+  }
+}

--- a/src/main/java/com/jobmatrix/repository/ClientRepository.java
+++ b/src/main/java/com/jobmatrix/repository/ClientRepository.java
@@ -1,0 +1,9 @@
+package com.jobmatrix.repository;
+
+import com.jobmatrix.entity.Client;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface ClientRepository extends JpaRepository<Client, UUID> {
+}

--- a/src/main/java/com/jobmatrix/repository/ClientRepository.java
+++ b/src/main/java/com/jobmatrix/repository/ClientRepository.java
@@ -1,6 +1,6 @@
 package com.jobmatrix.repository;
 
-import com.jobmatrix.entity.Client;
+import com.common.entity.Client;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.UUID;

--- a/src/main/java/com/jobmatrix/repository/JobPostingRepository.java
+++ b/src/main/java/com/jobmatrix/repository/JobPostingRepository.java
@@ -6,8 +6,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.UUID;
 
 @Repository
 public interface JobPostingRepository extends JpaRepository<JobPosting, Long> {
     List<JobPosting> findByJobPostingStatus(JobPostingStatus jobPostingStatus);
+    List<JobPosting> findByClientId(UUID clientId);
 } 

--- a/src/main/java/com/jobmatrix/service/JobPostingService.java
+++ b/src/main/java/com/jobmatrix/service/JobPostingService.java
@@ -4,9 +4,11 @@ import com.jobmatrix.dto.JobPostingDTO;
 import com.jobmatrix.entity.JobPosting;
 
 import java.util.List;
+import java.util.UUID;
 
 public interface JobPostingService {
     JobPosting createJobPosting(JobPostingDTO jobPostingDTO);
     List<JobPosting> getOpenJobPostings();
     JobPosting getJobPostingById(Long jobPostingId);
+    List<JobPosting> getJobPostingsByClientId(UUID clientId);
 } 

--- a/src/main/java/com/jobmatrix/serviceimpl/JobPostingServiceImpl.java
+++ b/src/main/java/com/jobmatrix/serviceimpl/JobPostingServiceImpl.java
@@ -6,7 +6,6 @@ import com.jobmatrix.entity.Category;
 import com.jobmatrix.entity.JobPosting;
 import com.jobmatrix.entity.JobPostingStatus;
 import com.jobmatrix.exceptionHandling.CategoryNotFoundException;
-import com.jobmatrix.exceptionHandling.JobPostingByClientIdNotFoundException;
 import com.jobmatrix.exceptionHandling.JobPostingNotFoundException;
 import com.jobmatrix.repository.CategoryRepository;
 import com.jobmatrix.repository.ClientRepository;
@@ -67,10 +66,7 @@ public class JobPostingServiceImpl implements JobPostingService {
         }
 
         List<JobPosting> jobPostings = jobPostingRepository.findByClientId(clientId);
-        // Check if job postings exist for the client
-        if (jobPostings.isEmpty()) {
-            throw new JobPostingByClientIdNotFoundException(clientId);
-        }
+
         return jobPostings;
     }
 

--- a/src/main/java/com/jobmatrix/serviceimpl/JobPostingServiceImpl.java
+++ b/src/main/java/com/jobmatrix/serviceimpl/JobPostingServiceImpl.java
@@ -1,12 +1,15 @@
 package com.jobmatrix.serviceimpl;
 
+import com.common.exceptionHandling.ClientNotFoundException;
 import com.jobmatrix.dto.JobPostingDTO;
 import com.jobmatrix.entity.Category;
 import com.jobmatrix.entity.JobPosting;
 import com.jobmatrix.entity.JobPostingStatus;
 import com.jobmatrix.exceptionHandling.CategoryNotFoundException;
+import com.jobmatrix.exceptionHandling.JobPostingByClientIdNotFoundException;
 import com.jobmatrix.exceptionHandling.JobPostingNotFoundException;
 import com.jobmatrix.repository.CategoryRepository;
+import com.jobmatrix.repository.ClientRepository;
 import com.jobmatrix.repository.JobPostingRepository;
 import com.jobmatrix.service.JobPostingService;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +26,7 @@ public class JobPostingServiceImpl implements JobPostingService {
 
     private final JobPostingRepository jobPostingRepository;
     private final CategoryRepository categoryRepository;
+    private final ClientRepository clientRepository;
     private final ModelMapper modelMapper;
 
     @Override
@@ -54,5 +58,21 @@ public class JobPostingServiceImpl implements JobPostingService {
         return jobPostingRepository.findById(jobPostingId)
                 .orElseThrow(() -> new JobPostingNotFoundException(jobPostingId));
     }
+
+    @Override
+    public List<JobPosting> getJobPostingsByClientId(UUID clientId) {
+        // Check if client exists
+        if (clientRepository.findById(clientId).isEmpty()) {
+            throw new ClientNotFoundException(clientId);
+        }
+
+        List<JobPosting> jobPostings = jobPostingRepository.findByClientId(clientId);
+        // Check if job postings exist for the client
+        if (jobPostings.isEmpty()) {
+            throw new JobPostingByClientIdNotFoundException(clientId);
+        }
+        return jobPostings;
+    }
+
 
 }

--- a/src/test/java/com/jobmatrix/controller/JobPostingControllerTest.java
+++ b/src/test/java/com/jobmatrix/controller/JobPostingControllerTest.java
@@ -81,4 +81,21 @@ public class JobPostingControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.title").value("Sample Job"));
     }
 
+    @Test
+    void testGetJobPostingsByClientId() throws Exception {
+        UUID clientId = UUID.randomUUID();
+        List<JobPosting> mockJobPostings = List.of(
+                JobPostingTestDataFactory.createJobPostingEntity(clientId),
+                JobPostingTestDataFactory.createJobPostingEntity(clientId)
+        );
+
+        Mockito.when(jobPostingService.getJobPostingsByClientId(clientId)).thenReturn(mockJobPostings);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/job_postings/client/" + clientId))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.length()").value(2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].jobPostingId").value(1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].title").value("Sample Job"));
+    }
+
 }

--- a/src/test/java/com/jobmatrix/controller/JobPostingControllerTest.java
+++ b/src/test/java/com/jobmatrix/controller/JobPostingControllerTest.java
@@ -85,8 +85,8 @@ public class JobPostingControllerTest {
     void testGetJobPostingsByClientId() throws Exception {
         UUID clientId = UUID.randomUUID();
         List<JobPosting> mockJobPostings = List.of(
-                JobPostingTestDataFactory.createJobPostingEntity(clientId),
-                JobPostingTestDataFactory.createJobPostingEntity(clientId)
+                JobPostingTestDataFactory.createJobPostingEntity(clientId, 1L, "Sample Job 1", "Description 1"),
+                JobPostingTestDataFactory.createJobPostingEntity(clientId, 2L, "Sample Job 2", "Description 2")
         );
 
         Mockito.when(jobPostingService.getJobPostingsByClientId(clientId)).thenReturn(mockJobPostings);
@@ -95,7 +95,9 @@ public class JobPostingControllerTest {
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.length()").value(2))
                 .andExpect(MockMvcResultMatchers.jsonPath("$[0].jobPostingId").value(1))
-                .andExpect(MockMvcResultMatchers.jsonPath("$[0].title").value("Sample Job"));
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].title").value("Sample Job 1"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[1].jobPostingId").value(2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[1].title").value("Sample Job 2"));
     }
 
 }

--- a/src/test/java/com/jobmatrix/exceptionHandling/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/jobmatrix/exceptionHandling/GlobalExceptionHandlerTest.java
@@ -34,11 +34,6 @@ class GlobalExceptionHandlerTest {
         public String throwClientNotFoundException() {
             throw new ClientNotFoundException(UUID.fromString("123e4567-e89b-12d3-a456-426614174000"));
         }
-
-        @GetMapping("/test-job-posting-by-client-id-not-found")
-        public String throwJobPostingByClientIdNotFoundException() {
-            throw new JobPostingByClientIdNotFoundException(UUID.fromString("123e4567-e89b-12d3-a456-426614174000"));
-        }
     }
 
     @BeforeEach
@@ -72,12 +67,5 @@ class GlobalExceptionHandlerTest {
                 .andExpect(content().string("Client not found with ID: 123e4567-e89b-12d3-a456-426614174000"));
     }
 
-    @Test
-    void handleJobPostingByClientIdNotFound_ShouldReturnNotFoundWithMessage() throws Exception {
-        mockMvc.perform(get("/test-job-posting-by-client-id-not-found")
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isNotFound())
-                .andExpect(content().string("No job postings found for client ID: 123e4567-e89b-12d3-a456-426614174000"));
-    }
 
 }

--- a/src/test/java/com/jobmatrix/exceptionHandling/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/jobmatrix/exceptionHandling/GlobalExceptionHandlerTest.java
@@ -1,5 +1,6 @@
 package com.jobmatrix.exceptionHandling;
 
+import com.common.exceptionHandling.ClientNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
@@ -7,6 +8,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -25,6 +28,16 @@ class GlobalExceptionHandlerTest {
         @GetMapping("/test-job-posting-not-found")
         public String throwJobPostingNotFoundException() {
             throw new JobPostingNotFoundException(7L);
+        }
+
+        @GetMapping("/test-client-not-found")
+        public String throwClientNotFoundException() {
+            throw new ClientNotFoundException(UUID.fromString("123e4567-e89b-12d3-a456-426614174000"));
+        }
+
+        @GetMapping("/test-job-posting-by-client-id-not-found")
+        public String throwJobPostingByClientIdNotFoundException() {
+            throw new JobPostingByClientIdNotFoundException(UUID.fromString("123e4567-e89b-12d3-a456-426614174000"));
         }
     }
 
@@ -49,6 +62,22 @@ class GlobalExceptionHandlerTest {
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isNotFound())
                 .andExpect(content().string("JobPosting not found at given jobPostingId: 7"));
+    }
+
+    @Test
+    void handleClientNotFound_ShouldReturnNotFoundWithMessage() throws Exception {
+        mockMvc.perform(get("/test-client-not-found")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(content().string("Client not found with ID: 123e4567-e89b-12d3-a456-426614174000"));
+    }
+
+    @Test
+    void handleJobPostingByClientIdNotFound_ShouldReturnNotFoundWithMessage() throws Exception {
+        mockMvc.perform(get("/test-job-posting-by-client-id-not-found")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(content().string("No job postings found for client ID: 123e4567-e89b-12d3-a456-426614174000"));
     }
 
 }

--- a/src/test/java/com/jobmatrix/service/JobPostingServiceImplTest.java
+++ b/src/test/java/com/jobmatrix/service/JobPostingServiceImplTest.java
@@ -6,7 +6,6 @@ import com.jobmatrix.entity.Category;
 import com.common.entity.Client;
 import com.jobmatrix.entity.JobPosting;
 import com.jobmatrix.entity.JobPostingStatus;
-import com.jobmatrix.exceptionHandling.JobPostingByClientIdNotFoundException;
 import com.jobmatrix.exceptionHandling.JobPostingNotFoundException;
 import com.jobmatrix.repository.CategoryRepository;
 import com.jobmatrix.repository.ClientRepository;
@@ -19,11 +18,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.modelmapper.ModelMapper;
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -254,20 +250,20 @@ public class JobPostingServiceImplTest {
     }
 
     @Test
-    void getJobPostingsByClientId_shouldThrowExceptionForClientWithNoPostings() {
+    void getJobPostingsByClientId_shouldReturnEmptyListWhenNoPostingsExist() {
         UUID clientId = UUID.randomUUID();
         // Mock client existence
         when(clientRepository.findById(clientId)).thenReturn(Optional.of(new Client()));
         // Mock empty job postings
         when(jobPostingRepository.findByClientId(clientId)).thenReturn(List.of());
 
-        JobPostingByClientIdNotFoundException exception = assertThrows(
-                JobPostingByClientIdNotFoundException.class,
-                () -> jobPostingService.getJobPostingsByClientId(clientId),
-                "No job postings found"
-        );
+        // Call the method
+        List<JobPosting> result = jobPostingService.getJobPostingsByClientId(clientId);
 
-        assertEquals("No job postings found for client ID: " + clientId, exception.getMessage());
+        // Assert result is empty
+        assertTrue(result.isEmpty());
+
+        // Verify interactions
         verify(clientRepository, times(1)).findById(clientId);
         verify(jobPostingRepository, times(1)).findByClientId(clientId);
     }

--- a/src/test/java/com/jobmatrix/service/JobPostingServiceImplTest.java
+++ b/src/test/java/com/jobmatrix/service/JobPostingServiceImplTest.java
@@ -3,7 +3,7 @@ package com.jobmatrix.service;
 import com.common.exceptionHandling.ClientNotFoundException;
 import com.jobmatrix.dto.JobPostingDTO;
 import com.jobmatrix.entity.Category;
-import com.jobmatrix.entity.Client;
+import com.common.entity.Client;
 import com.jobmatrix.entity.JobPosting;
 import com.jobmatrix.entity.JobPostingStatus;
 import com.jobmatrix.exceptionHandling.JobPostingByClientIdNotFoundException;

--- a/src/test/java/com/jobmatrix/service/JobPostingServiceImplTest.java
+++ b/src/test/java/com/jobmatrix/service/JobPostingServiceImplTest.java
@@ -1,11 +1,15 @@
 package com.jobmatrix.service;
 
+import com.common.exceptionHandling.ClientNotFoundException;
 import com.jobmatrix.dto.JobPostingDTO;
 import com.jobmatrix.entity.Category;
+import com.jobmatrix.entity.Client;
 import com.jobmatrix.entity.JobPosting;
 import com.jobmatrix.entity.JobPostingStatus;
+import com.jobmatrix.exceptionHandling.JobPostingByClientIdNotFoundException;
 import com.jobmatrix.exceptionHandling.JobPostingNotFoundException;
 import com.jobmatrix.repository.CategoryRepository;
+import com.jobmatrix.repository.ClientRepository;
 import com.jobmatrix.repository.JobPostingRepository;
 import com.jobmatrix.serviceimpl.JobPostingServiceImpl;
 import com.jobmatrix.test_utils.factory.JobPostingTestDataFactory;
@@ -38,6 +42,9 @@ public class JobPostingServiceImplTest {
 
     @Mock
     private CategoryRepository categoryRepository;
+
+    @Mock
+    private ClientRepository clientRepository;
 
     @Mock
     private ModelMapper modelMapper;
@@ -205,6 +212,64 @@ public class JobPostingServiceImplTest {
 
         assertEquals("JobPosting not found at given jobPostingId: " + jobPostingId, exception.getMessage());
         verify(jobPostingRepository, times(1)).findById(jobPostingId);
+    }
+
+    @Test
+    void getJobPostingsByClientId_shouldReturnJobPostingsForExistingClient() {
+        UUID clientId = UUID.randomUUID();
+        JobPosting mockJobPosting1 = JobPostingTestDataFactory.createJobPostingEntity(clientId);
+        JobPosting mockJobPosting2 = JobPostingTestDataFactory.createJobPostingEntity(clientId);
+
+        // Mock client existence
+        when(clientRepository.findById(clientId)).thenReturn(Optional.of(new Client()));
+        // Mock job postings
+        when(jobPostingRepository.findByClientId(clientId)).thenReturn(List.of(mockJobPosting1, mockJobPosting2));
+
+        List<JobPosting> result = jobPostingService.getJobPostingsByClientId(clientId);
+
+        assertNotNull(result);
+        assertEquals(2, result.size());
+        assertEquals(mockJobPosting1.getClientId(), result.get(0).getClientId());
+        assertEquals(mockJobPosting2.getClientId(), result.get(1).getClientId());
+
+        verify(clientRepository, times(1)).findById(clientId);
+        verify(jobPostingRepository, times(1)).findByClientId(clientId);
+    }
+
+    @Test
+    void getJobPostingsByClientId_shouldThrowClientNotFoundException() {
+        UUID clientId = UUID.randomUUID();
+
+        // Mock client non-existence
+        when(clientRepository.findById(clientId)).thenReturn(Optional.empty());
+
+        ClientNotFoundException exception = assertThrows(
+                ClientNotFoundException.class,
+                () -> jobPostingService.getJobPostingsByClientId(clientId),
+                "Client not found with ID"
+        );
+
+        assertEquals("Client not found with ID: " + clientId, exception.getMessage());
+        verify(clientRepository, times(1)).findById(clientId);
+    }
+
+    @Test
+    void getJobPostingsByClientId_shouldThrowExceptionForClientWithNoPostings() {
+        UUID clientId = UUID.randomUUID();
+        // Mock client existence
+        when(clientRepository.findById(clientId)).thenReturn(Optional.of(new Client()));
+        // Mock empty job postings
+        when(jobPostingRepository.findByClientId(clientId)).thenReturn(List.of());
+
+        JobPostingByClientIdNotFoundException exception = assertThrows(
+                JobPostingByClientIdNotFoundException.class,
+                () -> jobPostingService.getJobPostingsByClientId(clientId),
+                "No job postings found"
+        );
+
+        assertEquals("No job postings found for client ID: " + clientId, exception.getMessage());
+        verify(clientRepository, times(1)).findById(clientId);
+        verify(jobPostingRepository, times(1)).findByClientId(clientId);
     }
 
 

--- a/src/test/java/com/jobmatrix/test_utils/factory/JobPostingTestDataFactory.java
+++ b/src/test/java/com/jobmatrix/test_utils/factory/JobPostingTestDataFactory.java
@@ -50,6 +50,26 @@ public class JobPostingTestDataFactory {
                 .updatedAt(LocalDateTime.now())
                 .build();
     }
+
+    public static JobPosting createJobPostingEntity(UUID clientId, Long jobPostingId, String title, String description){
+        return JobPosting.builder()
+                .jobPostingId(jobPostingId)
+                .clientId(clientId)
+                .title(title)
+                .description(description)
+                .budgetType(BUDGET_TYPE)
+                .hourlyMinRate(HOURLY_MIN_RATE)
+                .hourlyMaxRate(HOURLY_MAX_RATE)
+                .fixedPrice(FIXED_PRICE)
+                .projectDuration(PROJECT_DURATION)
+                .experienceLevel(EXPERIENCE_LEVEL)
+                .jobPostingStatus(STATUS)
+                .category(createMockCategory())
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+    }
+
     private static Category createMockCategory() {
         return Category.builder()
                 .categoryId(CATEGORY_ID)


### PR DESCRIPTION
- Add GET mapping for `getJobPostingsByClientId()`, update Client Repository with `findByClientId()`, implement in `ServiceImpl`, and write unit tests.
- Add Exception Handlers for `ClientIdNotFoundException` and `JobPostingNotFoundByClientIdException`, and clean up unused exceptions and imports.
- Update import paths for `Client` Entity and add a new utility method.
