### PR TITLE
JMK_66: Endpoint to get all categories and specialities

### DIFF
--- a/src/main/java/com/jobmatrix/controller/JobPostingController.java
+++ b/src/main/java/com/jobmatrix/controller/JobPostingController.java
@@ -1,6 +1,7 @@
 package com.jobmatrix.controller;
 
 import com.jobmatrix.dto.JobPostingDTO;
+import com.jobmatrix.entity.Category;
 import com.jobmatrix.entity.JobPosting;
 import com.jobmatrix.service.JobPostingService;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -36,5 +37,11 @@ public class JobPostingController {
     public ResponseEntity<JobPosting> getJobPostingById(@PathVariable Long jobPostingId){
         JobPosting jobPosting = jobPostingService.getJobPostingById(jobPostingId);
         return ResponseEntity.ok(jobPosting);
+    }
+
+    @GetMapping("/categories")
+    public ResponseEntity<List<Category>> getCategories() {
+        List<Category> categories = jobPostingService.getCategories();
+        return ResponseEntity.ok(categories);
     }
 } 

--- a/src/main/java/com/jobmatrix/service/JobPostingService.java
+++ b/src/main/java/com/jobmatrix/service/JobPostingService.java
@@ -1,6 +1,7 @@
 package com.jobmatrix.service;
 
 import com.jobmatrix.dto.JobPostingDTO;
+import com.jobmatrix.entity.Category;
 import com.jobmatrix.entity.JobPosting;
 
 import java.util.List;
@@ -9,4 +10,5 @@ public interface JobPostingService {
     JobPosting createJobPosting(JobPostingDTO jobPostingDTO);
     List<JobPosting> getOpenJobPostings();
     JobPosting getJobPostingById(Long jobPostingId);
+    List<Category> getCategories();
 } 

--- a/src/main/java/com/jobmatrix/serviceimpl/JobPostingServiceImpl.java
+++ b/src/main/java/com/jobmatrix/serviceimpl/JobPostingServiceImpl.java
@@ -55,4 +55,8 @@ public class JobPostingServiceImpl implements JobPostingService {
                 .orElseThrow(() -> new JobPostingNotFoundException(jobPostingId));
     }
 
+    @Override
+    public List<Category> getCategories() {
+        return categoryRepository.findAll();
+    }
 }

--- a/src/test/java/com/jobmatrix/controller/JobPostingControllerTest.java
+++ b/src/test/java/com/jobmatrix/controller/JobPostingControllerTest.java
@@ -2,6 +2,7 @@ package com.jobmatrix.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jobmatrix.dto.JobPostingDTO;
+import com.jobmatrix.entity.Category;
 import com.jobmatrix.entity.JobPosting;
 import com.jobmatrix.service.JobPostingService;
 import com.jobmatrix.test_utils.factory.JobPostingTestDataFactory;
@@ -81,4 +82,23 @@ public class JobPostingControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.title").value("Sample Job"));
     }
 
+    @Test
+    void testGetCategories() throws Exception {
+        List<Category> mockCategories = List.of(
+                JobPostingTestDataFactory.createMockCategory(),
+                JobPostingTestDataFactory.createMockCategory()
+        );
+
+        Mockito.when(jobPostingService.getCategories()).thenReturn(mockCategories);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/job_postings/categories"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.length()").value(2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].categoryId").value(1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].category").value("Sample Category"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].speciality").value("Sample Speciality"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[1].categoryId").value(1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[1].category").value("Sample Category"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[1].speciality").value("Sample Speciality"));
+}
 }

--- a/src/test/java/com/jobmatrix/test_utils/factory/JobPostingTestDataFactory.java
+++ b/src/test/java/com/jobmatrix/test_utils/factory/JobPostingTestDataFactory.java
@@ -50,7 +50,7 @@ public class JobPostingTestDataFactory {
                 .updatedAt(LocalDateTime.now())
                 .build();
     }
-    private static Category createMockCategory() {
+    public static Category createMockCategory() {
         return Category.builder()
                 .categoryId(CATEGORY_ID)
                 .category("Sample Category")


### PR DESCRIPTION
This PR adds a new REST endpoint in the JobPostingController to retrieve all job categories stored in the database. It also includes a corresponding service method, service implementation, and unit test.

**Endpoint:**
GET /api/v1/job_postings/categories 

This endpoint returns a list of Category objects, each containing the following fields:
- categoryId
- category
- speciality