### PR TITLE
JMK_66: Endpoint to get all categories and specialities

### DIFF
--- a/src/main/java/com/jobmatrix/controller/JobPostingController.java
+++ b/src/main/java/com/jobmatrix/controller/JobPostingController.java
@@ -1,6 +1,7 @@
 package com.jobmatrix.controller;
 
 import com.jobmatrix.dto.JobPostingDTO;
+import com.jobmatrix.entity.Category;
 import com.jobmatrix.entity.JobPosting;
 import com.jobmatrix.service.JobPostingService;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -43,4 +44,11 @@ public class JobPostingController {
         List<JobPosting> jobPostings = jobPostingService.getJobPostingsByClientId(clientId);
         return ResponseEntity.ok(jobPostings);
     }
+
+    @GetMapping("/categories")
+    public ResponseEntity<List<Category>> getCategories() {
+        List<Category> categories = jobPostingService.getCategories();
+        return ResponseEntity.ok(categories);
+    }
+
 } 

--- a/src/main/java/com/jobmatrix/service/JobPostingService.java
+++ b/src/main/java/com/jobmatrix/service/JobPostingService.java
@@ -1,6 +1,7 @@
 package com.jobmatrix.service;
 
 import com.jobmatrix.dto.JobPostingDTO;
+import com.jobmatrix.entity.Category;
 import com.jobmatrix.entity.JobPosting;
 
 import java.util.List;
@@ -11,4 +12,5 @@ public interface JobPostingService {
     List<JobPosting> getOpenJobPostings();
     JobPosting getJobPostingById(Long jobPostingId);
     List<JobPosting> getJobPostingsByClientId(UUID clientId);
+    List<Category> getCategories();
 } 

--- a/src/main/java/com/jobmatrix/serviceimpl/JobPostingServiceImpl.java
+++ b/src/main/java/com/jobmatrix/serviceimpl/JobPostingServiceImpl.java
@@ -70,5 +70,8 @@ public class JobPostingServiceImpl implements JobPostingService {
         return jobPostings;
     }
 
-
+    @Override
+    public List<Category> getCategories() {
+        return categoryRepository.findAll();
+    }
 }

--- a/src/test/java/com/jobmatrix/controller/JobPostingControllerTest.java
+++ b/src/test/java/com/jobmatrix/controller/JobPostingControllerTest.java
@@ -104,8 +104,8 @@ public class JobPostingControllerTest {
     @Test
     void testGetCategories() throws Exception {
         List<Category> mockCategories = List.of(
-                JobPostingTestDataFactory.createMockCategory(),
-                JobPostingTestDataFactory.createMockCategory()
+                JobPostingTestDataFactory.createMockCategory(3L, "Sample Category", "Sample Speciality"),
+                JobPostingTestDataFactory.createMockCategory(1L, "Test Category", "Test Speciality")
         );
 
         Mockito.when(jobPostingService.getCategories()).thenReturn(mockCategories);
@@ -113,11 +113,11 @@ public class JobPostingControllerTest {
         mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/job_postings/categories"))
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.length()").value(2))
-                .andExpect(MockMvcResultMatchers.jsonPath("$[0].categoryId").value(1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].categoryId").value(3))
                 .andExpect(MockMvcResultMatchers.jsonPath("$[0].category").value("Sample Category"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$[0].speciality").value("Sample Speciality"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$[1].categoryId").value(1))
-                .andExpect(MockMvcResultMatchers.jsonPath("$[1].category").value("Sample Category"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$[1].speciality").value("Sample Speciality"));
+                .andExpect(MockMvcResultMatchers.jsonPath("$[1].category").value("Test Category"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[1].speciality").value("Test Speciality"));
     }
 }

--- a/src/test/java/com/jobmatrix/controller/JobPostingControllerTest.java
+++ b/src/test/java/com/jobmatrix/controller/JobPostingControllerTest.java
@@ -2,6 +2,7 @@ package com.jobmatrix.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jobmatrix.dto.JobPostingDTO;
+import com.jobmatrix.entity.Category;
 import com.jobmatrix.entity.JobPosting;
 import com.jobmatrix.service.JobPostingService;
 import com.jobmatrix.test_utils.factory.JobPostingTestDataFactory;
@@ -100,4 +101,23 @@ public class JobPostingControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$[1].title").value("Sample Job 2"));
     }
 
+    @Test
+    void testGetCategories() throws Exception {
+        List<Category> mockCategories = List.of(
+                JobPostingTestDataFactory.createMockCategory(),
+                JobPostingTestDataFactory.createMockCategory()
+        );
+
+        Mockito.when(jobPostingService.getCategories()).thenReturn(mockCategories);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/job_postings/categories"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.length()").value(2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].categoryId").value(1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].category").value("Sample Category"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].speciality").value("Sample Speciality"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[1].categoryId").value(1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[1].category").value("Sample Category"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[1].speciality").value("Sample Speciality"));
+    }
 }

--- a/src/test/java/com/jobmatrix/service/JobPostingServiceImplTest.java
+++ b/src/test/java/com/jobmatrix/service/JobPostingServiceImplTest.java
@@ -269,4 +269,18 @@ public class JobPostingServiceImplTest {
     }
 
 
+    @Test
+    void testGetCategories_ShouldReturnListOfCategories() {
+        Category category1 = JobPostingTestDataFactory.createMockCategory(3L, "Sample Category", "Sample Speciality");
+        Category category2 = JobPostingTestDataFactory.createMockCategory(1L, "Test Category", "Test Speciality");
+        List<Category> mockCategories = List.of(category1, category2);
+        when(categoryRepository.findAll()).thenReturn(mockCategories);
+        List<Category> result = jobPostingService.getCategories();
+        assertNotNull(result);
+        assertEquals(2, result.size());
+        assertEquals("Sample Category", result.get(0).getCategory());
+        assertEquals("Test Speciality", result.get(1).getSpeciality());
+        verify(categoryRepository, times(1)).findAll();
+    }
+
 }

--- a/src/test/java/com/jobmatrix/test_utils/factory/JobPostingTestDataFactory.java
+++ b/src/test/java/com/jobmatrix/test_utils/factory/JobPostingTestDataFactory.java
@@ -45,7 +45,7 @@ public class JobPostingTestDataFactory {
                 .projectDuration(PROJECT_DURATION)
                 .experienceLevel(EXPERIENCE_LEVEL)
                 .jobPostingStatus(STATUS)
-                .category(createMockCategory())
+                .category(createMockCategory(2L, "Test Category", "Test Speciality"))
                 .createdAt(LocalDateTime.now())
                 .updatedAt(LocalDateTime.now())
                 .build();
@@ -64,17 +64,17 @@ public class JobPostingTestDataFactory {
                 .projectDuration(PROJECT_DURATION)
                 .experienceLevel(EXPERIENCE_LEVEL)
                 .jobPostingStatus(STATUS)
-                .category(createMockCategory())
+                .category(createMockCategory(5L, "Test Category", "Test Speciality"))
                 .createdAt(LocalDateTime.now())
                 .updatedAt(LocalDateTime.now())
                 .build();
     }
 
-    public static Category createMockCategory() {
+    public static Category createMockCategory(Long categoryId, String category, String speciality) {
         return Category.builder()
-                .categoryId(CATEGORY_ID)
-                .category("Sample Category")
-                .speciality("Sample Speciality")
+                .categoryId(categoryId)
+                .category(category)
+                .speciality(speciality)
                 .createdAt(LocalDateTime.now())
                 .updatedAt(LocalDateTime.now())
                 .build();

--- a/src/test/java/com/jobmatrix/test_utils/factory/JobPostingTestDataFactory.java
+++ b/src/test/java/com/jobmatrix/test_utils/factory/JobPostingTestDataFactory.java
@@ -70,7 +70,7 @@ public class JobPostingTestDataFactory {
                 .build();
     }
 
-    private static Category createMockCategory() {
+    public static Category createMockCategory() {
         return Category.builder()
                 .categoryId(CATEGORY_ID)
                 .category("Sample Category")


### PR DESCRIPTION
This PR adds a new REST endpoint in the JobPostingController to retrieve all job categories stored in the database. It also includes a corresponding service method, service implementation, and unit test.

**Endpoint:**
GET /api/v1/job_postings/categories

This endpoint returns a list of Category objects, each containing the following fields:
- categoryId
- category
- speciality
- createdAt
- updatedAt