### PR TITLE
JMK_74: PATCH Endpoint to update Job Posting created by client

### DIFF
--- a/src/main/java/com/jobmatrix/controller/JobPostingController.java
+++ b/src/main/java/com/jobmatrix/controller/JobPostingController.java
@@ -1,10 +1,12 @@
 package com.jobmatrix.controller;
 
 import com.jobmatrix.dto.JobPostingDTO;
+import com.jobmatrix.dto.JobPostingUpdateRequest;
 import com.jobmatrix.entity.Category;
 import com.jobmatrix.entity.JobPosting;
 import com.jobmatrix.service.JobPostingService;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -51,4 +53,12 @@ public class JobPostingController {
         return ResponseEntity.ok(categories);
     }
 
+    @PatchMapping("/{job_Posting_Id}")
+    public ResponseEntity<JobPosting> updateJobPosting(
+            @PathVariable Long job_Posting_Id,
+            @Valid @RequestBody JobPostingUpdateRequest jobPostingUpdateRequest
+    ){
+        JobPosting updatedJobPosting = jobPostingService.updateJobPosting(job_Posting_Id, jobPostingUpdateRequest);
+        return ResponseEntity.ok(updatedJobPosting);
+    }
 } 

--- a/src/main/java/com/jobmatrix/controller/JobPostingController.java
+++ b/src/main/java/com/jobmatrix/controller/JobPostingController.java
@@ -53,12 +53,12 @@ public class JobPostingController {
         return ResponseEntity.ok(categories);
     }
 
-    @PatchMapping("/{job_Posting_Id}")
+    @PatchMapping("/{job_posting_id}")
     public ResponseEntity<JobPosting> updateJobPosting(
-            @PathVariable Long job_Posting_Id,
+            @PathVariable Long job_posting_id,
             @Valid @RequestBody JobPostingUpdateRequest jobPostingUpdateRequest
     ){
-        JobPosting updatedJobPosting = jobPostingService.updateJobPosting(job_Posting_Id, jobPostingUpdateRequest);
+        JobPosting updatedJobPosting = jobPostingService.updateJobPosting(job_posting_id, jobPostingUpdateRequest);
         return ResponseEntity.ok(updatedJobPosting);
     }
 } 

--- a/src/main/java/com/jobmatrix/dto/JobPostingUpdateRequest.java
+++ b/src/main/java/com/jobmatrix/dto/JobPostingUpdateRequest.java
@@ -1,0 +1,23 @@
+package com.jobmatrix.dto;
+
+import com.jobmatrix.entity.BudgetType;
+import com.jobmatrix.entity.ExperienceLevel;
+import com.jobmatrix.entity.ProjectDuration;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
+public class JobPostingUpdateRequest {
+    private String title;
+    private String description;
+    private BudgetType budgetType;
+    private Integer hourlyMinRate;
+    private Integer hourlyMaxRate;
+    private Integer fixedPrice;
+    private ProjectDuration projectDuration;
+    private ExperienceLevel experienceLevel;
+    private Long categoryId;
+}

--- a/src/main/java/com/jobmatrix/service/JobPostingService.java
+++ b/src/main/java/com/jobmatrix/service/JobPostingService.java
@@ -1,6 +1,7 @@
 package com.jobmatrix.service;
 
 import com.jobmatrix.dto.JobPostingDTO;
+import com.jobmatrix.dto.JobPostingUpdateRequest;
 import com.jobmatrix.entity.Category;
 import com.jobmatrix.entity.JobPosting;
 
@@ -13,4 +14,5 @@ public interface JobPostingService {
     JobPosting getJobPostingById(Long jobPostingId);
     List<JobPosting> getJobPostingsByClientId(UUID clientId);
     List<Category> getCategories();
+    JobPosting updateJobPosting(Long job_Posting_Id, JobPostingUpdateRequest jobPostingUpdateRequest);
 } 

--- a/src/main/java/com/jobmatrix/serviceimpl/JobPostingServiceImpl.java
+++ b/src/main/java/com/jobmatrix/serviceimpl/JobPostingServiceImpl.java
@@ -78,26 +78,25 @@ public class JobPostingServiceImpl implements JobPostingService {
 
     @Transactional
     @Override
-    public JobPosting updateJobPosting(Long job_Posting_Id, JobPostingUpdateRequest request) {
+    public JobPosting updateJobPosting(Long job_posting_id, JobPostingUpdateRequest request) {
 
-        JobPosting jobPosting = jobPostingRepository.findById(job_Posting_Id)
-                .orElseThrow(() -> new JobPostingNotFoundException(job_Posting_Id));
+        JobPosting jobPosting = jobPostingRepository.findById(job_posting_id)
+                .orElseThrow(() -> new JobPostingNotFoundException(job_posting_id));
 
         modelMapper.getConfiguration().setSkipNullEnabled(true);
 
-        // Temporarily exclude category from mapping
-        Long categoryId = request.getCategoryId();
-        request.setCategoryId(null);
-        modelMapper.map(request, jobPosting);
-        request.setCategoryId(categoryId);
+        if (request.getCategoryId() == null) {
+            modelMapper.map(request, jobPosting);
+        } else {
+            Long categoryId = request.getCategoryId();
+            request.setCategoryId(null); // prevent automatic mapping of categoryId
+            modelMapper.map(request, jobPosting);
+            request.setCategoryId(categoryId); // restore it
 
-        // Manually handle category if present
-        if (categoryId != null) {
             Category category = categoryRepository.findById(categoryId)
                     .orElseThrow(() -> new CategoryNotFoundException(categoryId));
             jobPosting.setCategory(category);
         }
-
         return jobPostingRepository.save(jobPosting);
     }
 

--- a/src/main/java/com/jobmatrix/serviceimpl/JobPostingServiceImpl.java
+++ b/src/main/java/com/jobmatrix/serviceimpl/JobPostingServiceImpl.java
@@ -2,6 +2,7 @@ package com.jobmatrix.serviceimpl;
 
 import com.common.exceptionHandling.ClientNotFoundException;
 import com.jobmatrix.dto.JobPostingDTO;
+import com.jobmatrix.dto.JobPostingUpdateRequest;
 import com.jobmatrix.entity.Category;
 import com.jobmatrix.entity.JobPosting;
 import com.jobmatrix.entity.JobPostingStatus;
@@ -73,5 +74,18 @@ public class JobPostingServiceImpl implements JobPostingService {
     @Override
     public List<Category> getCategories() {
         return categoryRepository.findAll();
+    }
+
+    @Transactional
+    @Override
+    public JobPosting updateJobPosting(Long job_Posting_Id, JobPostingUpdateRequest jobPostingUpdateRequest){
+
+        JobPosting tempJobPosting = jobPostingRepository.findById(job_Posting_Id)
+                .orElseThrow(() -> new JobPostingNotFoundException(job_Posting_Id));
+
+        modelMapper.getConfiguration().setSkipNullEnabled(true);
+        modelMapper.map(jobPostingUpdateRequest, tempJobPosting);
+
+        return jobPostingRepository.save(tempJobPosting);
     }
 }

--- a/src/main/java/com/jobmatrix/serviceimpl/JobPostingServiceImpl.java
+++ b/src/main/java/com/jobmatrix/serviceimpl/JobPostingServiceImpl.java
@@ -78,14 +78,27 @@ public class JobPostingServiceImpl implements JobPostingService {
 
     @Transactional
     @Override
-    public JobPosting updateJobPosting(Long job_Posting_Id, JobPostingUpdateRequest jobPostingUpdateRequest){
+    public JobPosting updateJobPosting(Long job_Posting_Id, JobPostingUpdateRequest request) {
 
-        JobPosting tempJobPosting = jobPostingRepository.findById(job_Posting_Id)
+        JobPosting jobPosting = jobPostingRepository.findById(job_Posting_Id)
                 .orElseThrow(() -> new JobPostingNotFoundException(job_Posting_Id));
 
         modelMapper.getConfiguration().setSkipNullEnabled(true);
-        modelMapper.map(jobPostingUpdateRequest, tempJobPosting);
 
-        return jobPostingRepository.save(tempJobPosting);
+        // Temporarily exclude category from mapping
+        Long categoryId = request.getCategoryId();
+        request.setCategoryId(null);
+        modelMapper.map(request, jobPosting);
+        request.setCategoryId(categoryId);
+
+        // Manually handle category if present
+        if (categoryId != null) {
+            Category category = categoryRepository.findById(categoryId)
+                    .orElseThrow(() -> new CategoryNotFoundException(categoryId));
+            jobPosting.setCategory(category);
+        }
+
+        return jobPostingRepository.save(jobPosting);
     }
+
 }

--- a/src/test/java/com/jobmatrix/controller/JobPostingControllerTest.java
+++ b/src/test/java/com/jobmatrix/controller/JobPostingControllerTest.java
@@ -2,6 +2,9 @@ package com.jobmatrix.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jobmatrix.dto.JobPostingDTO;
+import com.jobmatrix.dto.JobPostingUpdateRequest;
+import com.jobmatrix.entity.BudgetType;
+import com.jobmatrix.entity.ExperienceLevel;
 import com.jobmatrix.entity.Category;
 import com.jobmatrix.entity.JobPosting;
 import com.jobmatrix.service.JobPostingService;
@@ -119,5 +122,65 @@ public class JobPostingControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$[1].categoryId").value(1))
                 .andExpect(MockMvcResultMatchers.jsonPath("$[1].category").value("Test Category"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$[1].speciality").value("Test Speciality"));
+    }
+
+    @Test
+    void testUpdateJobPostingTest() throws Exception {
+        // Create base entity with initial values
+        JobPosting updatedJobPostingEntity = JobPostingTestDataFactory.createJobPostingEntity(UUID.randomUUID());
+
+        // Update entity with new values
+        updatedJobPostingEntity = updatedJobPostingEntity.toBuilder()
+                .title("Updated Job Title")
+                .description("Updated job description")
+                .budgetType(BudgetType.FIXED)
+                .fixedPrice(5000)
+                .hourlyMinRate(0)
+                .hourlyMaxRate(0)
+                .experienceLevel(ExperienceLevel.BEGINNER)
+                .category(JobPostingTestDataFactory.createMockCategory(3L, "Updated Category", "Updated Speciality"))
+                .build();
+
+        // Create and update the request
+        JobPostingUpdateRequest updateRequest = JobPostingTestDataFactory.createJobPostingUpdateRequest();
+
+        updateRequest = updateRequest.toBuilder()
+                .title("Updated Job Title")
+                .description("Updated job description")
+                .budgetType(BudgetType.FIXED)
+                .fixedPrice(5000)
+                .hourlyMinRate(0)
+                .hourlyMaxRate(0)
+                .experienceLevel(ExperienceLevel.BEGINNER)
+                .categoryId(3L)
+                .build();
+
+        Long jobPostingId = 1L;
+
+        Mockito.when(jobPostingService.updateJobPosting(Mockito.eq(jobPostingId), Mockito.any(JobPostingUpdateRequest.class)))
+                .thenReturn(updatedJobPostingEntity);
+
+        mockMvc.perform(MockMvcRequestBuilders.patch("/api/v1/job_postings/" + jobPostingId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updateRequest)))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.jobPostingId").value(jobPostingId))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.title").value("Updated Job Title"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.description").value("Updated job description"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.budgetType").value("FIXED"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.fixedPrice").value(5000))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.hourlyMinRate").value(0))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.hourlyMaxRate").value(0))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.experienceLevel").value("BEGINNER"))
+                // verify other fields remain unchanged
+                .andExpect(MockMvcResultMatchers.jsonPath("$.projectDuration").value(updatedJobPostingEntity.getProjectDuration().toString()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.jobPostingStatus").value(updatedJobPostingEntity.getJobPostingStatus().toString()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.category.categoryId").value(3))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.category.category").value("Updated Category"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.category.speciality").value("Updated Speciality"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.createdAt").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.updatedAt").exists());
+
+        Mockito.verify(jobPostingService).updateJobPosting(Mockito.eq(jobPostingId), Mockito.any(JobPostingUpdateRequest.class));
     }
 }

--- a/src/test/java/com/jobmatrix/service/JobPostingServiceImplTest.java
+++ b/src/test/java/com/jobmatrix/service/JobPostingServiceImplTest.java
@@ -2,10 +2,14 @@ package com.jobmatrix.service;
 
 import com.common.exceptionHandling.ClientNotFoundException;
 import com.jobmatrix.dto.JobPostingDTO;
+import com.jobmatrix.dto.JobPostingUpdateRequest;
+import com.jobmatrix.entity.BudgetType;
+import com.jobmatrix.entity.ExperienceLevel;
 import com.jobmatrix.entity.Category;
 import com.common.entity.Client;
 import com.jobmatrix.entity.JobPosting;
 import com.jobmatrix.entity.JobPostingStatus;
+import com.jobmatrix.exceptionHandling.CategoryNotFoundException;
 import com.jobmatrix.exceptionHandling.JobPostingNotFoundException;
 import com.jobmatrix.repository.CategoryRepository;
 import com.jobmatrix.repository.ClientRepository;
@@ -281,6 +285,92 @@ public class JobPostingServiceImplTest {
         assertEquals("Sample Category", result.get(0).getCategory());
         assertEquals("Test Speciality", result.get(1).getSpeciality());
         verify(categoryRepository, times(1)).findAll();
+    }
+
+    @Test
+    void updateJobPosting_shouldUpdateAndReturnJobPosting() {
+        Long jobPostingId = 1L;
+        UUID clientId = UUID.randomUUID();
+        Long categoryId = 1L;
+
+        JobPosting existingJobPosting = JobPostingTestDataFactory.createJobPostingEntity(clientId);
+        JobPostingUpdateRequest updateRequest = JobPostingTestDataFactory.createJobPostingUpdateRequest();
+        Category updatedCategory = JobPostingTestDataFactory.createMockCategory(categoryId, "Updated Category", "Updated Speciality");
+
+        JobPosting updatedJobPosting = JobPostingTestDataFactory.createUpdatedJobPostingEntity(
+                jobPostingId, clientId, updateRequest, updatedCategory, existingJobPosting.getCreatedAt());
+
+        when(jobPostingRepository.findById(jobPostingId)).thenReturn(Optional.of(existingJobPosting));
+        when(categoryRepository.findById(categoryId)).thenReturn(Optional.of(updatedCategory));
+
+        org.modelmapper.config.Configuration mockConfig = mock(org.modelmapper.config.Configuration.class);
+        when(modelMapper.getConfiguration()).thenReturn(mockConfig);
+
+        doAnswer(invocation -> {
+            JobPostingUpdateRequest src = invocation.getArgument(0);
+            JobPosting dest = invocation.getArgument(1);
+            dest.setTitle(src.getTitle());
+            dest.setDescription(src.getDescription());
+            dest.setHourlyMinRate(src.getHourlyMinRate());
+            dest.setHourlyMaxRate(src.getHourlyMaxRate());
+            dest.setProjectDuration(src.getProjectDuration());
+            dest.setExperienceLevel(src.getExperienceLevel());
+            return null;
+        }).when(modelMapper).map(updateRequest, existingJobPosting);
+
+        when(jobPostingRepository.save(existingJobPosting)).thenReturn(updatedJobPosting);
+
+        JobPosting result = jobPostingService.updateJobPosting(jobPostingId, updateRequest);
+
+        assertNotNull(result);
+        assertEquals(updateRequest.getTitle(), result.getTitle());
+        assertEquals(updateRequest.getDescription(), result.getDescription());
+        assertEquals(updatedCategory, result.getCategory());
+
+        verify(jobPostingRepository, times(1)).findById(jobPostingId);
+        verify(modelMapper, times(1)).getConfiguration();
+        verify(mockConfig, times(1)).setSkipNullEnabled(true);
+        verify(modelMapper, times(1)).map(updateRequest, existingJobPosting);
+        verify(categoryRepository, times(1)).findById(categoryId);
+        verify(jobPostingRepository, times(1)).save(existingJobPosting);
+    }
+
+    @Test
+    void updateJobPosting_shouldThrowException_whenJobPostingNotFound() {
+        Long jobPostingId = 99L;
+        JobPostingUpdateRequest updateRequest = JobPostingTestDataFactory.createJobPostingUpdateRequest();
+
+        when(jobPostingRepository.findById(jobPostingId)).thenReturn(Optional.empty());
+
+        assertThrows(JobPostingNotFoundException.class,
+                () -> jobPostingService.updateJobPosting(jobPostingId, updateRequest));
+
+        verify(jobPostingRepository, times(1)).findById(jobPostingId);
+        verify(modelMapper, never()).map(any(), any());
+        verify(jobPostingRepository, never()).save(any());
+    }
+
+    @Test
+    void updateJobPosting_shouldThrowException_whenCategoryNotFound() {
+        Long jobPostingId = 1L;
+        UUID clientId = UUID.randomUUID();
+        JobPosting existingJobPosting = JobPostingTestDataFactory.createJobPostingEntity(clientId);
+        JobPostingUpdateRequest updateRequest = JobPostingTestDataFactory.createJobPostingUpdateRequest();
+
+        when(jobPostingRepository.findById(jobPostingId)).thenReturn(Optional.of(existingJobPosting));
+        when(categoryRepository.findById(updateRequest.getCategoryId())).thenReturn(Optional.empty());
+
+        org.modelmapper.config.Configuration mockConfig = mock(org.modelmapper.config.Configuration.class);
+        when(modelMapper.getConfiguration()).thenReturn(mockConfig);
+
+        doAnswer(invocation -> null).when(modelMapper).map(updateRequest, existingJobPosting);
+
+        assertThrows(CategoryNotFoundException.class,
+                () -> jobPostingService.updateJobPosting(jobPostingId, updateRequest));
+
+        verify(jobPostingRepository, times(1)).findById(jobPostingId);
+        verify(categoryRepository, times(1)).findById(updateRequest.getCategoryId());
+        verify(jobPostingRepository, never()).save(any());
     }
 
 }

--- a/src/test/java/com/jobmatrix/test_utils/factory/JobPostingTestDataFactory.java
+++ b/src/test/java/com/jobmatrix/test_utils/factory/JobPostingTestDataFactory.java
@@ -1,6 +1,7 @@
 package com.jobmatrix.test_utils.factory;
 
 import com.jobmatrix.dto.JobPostingDTO;
+import com.jobmatrix.dto.JobPostingUpdateRequest;
 import com.jobmatrix.entity.*;
 
 import java.time.LocalDateTime;
@@ -76,6 +77,38 @@ public class JobPostingTestDataFactory {
                 .category(category)
                 .speciality(speciality)
                 .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+    }
+
+    public static JobPostingUpdateRequest createJobPostingUpdateRequest() {
+        return JobPostingUpdateRequest.builder()
+                .title("Updated " + TITLE)
+                .description("Updated " + DESCRIPTION)
+                .budgetType(BUDGET_TYPE)
+                .hourlyMinRate(HOURLY_MIN_RATE + 10)
+                .hourlyMaxRate(HOURLY_MAX_RATE + 10)
+                .projectDuration(PROJECT_DURATION)
+                .experienceLevel(EXPERIENCE_LEVEL)
+                .categoryId(CATEGORY_ID)
+                .build();
+    }
+
+    public static JobPosting createUpdatedJobPostingEntity(Long jobPostingId, UUID clientId, JobPostingUpdateRequest request, Category category, LocalDateTime createdAt) {
+        return JobPosting.builder()
+                .jobPostingId(jobPostingId)
+                .clientId(clientId)
+                .title(request.getTitle())
+                .description(request.getDescription())
+                .budgetType(request.getBudgetType())
+                .hourlyMinRate(request.getHourlyMinRate())
+                .hourlyMaxRate(request.getHourlyMaxRate())
+                .fixedPrice(0)
+                .projectDuration(request.getProjectDuration())
+                .experienceLevel(request.getExperienceLevel())
+                .jobPostingStatus(JobPostingStatus.OPEN)
+                .category(category)
+                .createdAt(createdAt)
                 .updatedAt(LocalDateTime.now())
                 .build();
     }


### PR DESCRIPTION
Added a new PATCH endpoint to enable partial updates of job posting records. This endpoint allows clients to update specific fields of an existing job posting without needing to provide the complete object.

- **Endpoint**: `/api/v1/job_postings/{job_posting_id}`
- **Request Parameters**:
  - `job_posting_id` (path variable): Long - Unique identifier of the job posting
  - `jobPostingUpdateRequest` (request body)

- Returns 200 OK with updated entity on success
- Returns 404 Not Found if job posting doesn't exist