### PR TITLE
JMK_77: GET endpoint to return all the job postings depending on the statuses passed

### DIFF
--- a/src/main/java/com/jobmatrix/controller/JobPostingController.java
+++ b/src/main/java/com/jobmatrix/controller/JobPostingController.java
@@ -1,5 +1,6 @@
 package com.jobmatrix.controller;
 
+import com.common.utility.StringToList;
 import com.jobmatrix.dto.JobPostingDTO;
 import com.jobmatrix.dto.JobPostingUpdateRequest;
 import com.jobmatrix.entity.Category;
@@ -70,12 +71,10 @@ public class JobPostingController {
     public ResponseEntity<Map<JobPostingStatus, List<JobPostingDTO>>> getJobPostingsByStatuses(
             @PathVariable UUID clientId,
             @PathVariable String statuses) {
-        // Convert comma separated string to list of JobPostingStatus enum values
-        List<JobPostingStatus> statusList = Arrays.stream(statuses.split(","))
-                .map(String::toUpperCase)
-                .map(JobPostingStatus::valueOf)
-                .collect(Collectors.toList());
+
+        List<JobPostingStatus> statusList = StringToList.convertToEnumList(statuses, JobPostingStatus.class);
         Map<JobPostingStatus, List<JobPostingDTO>> result = jobPostingService.getJobPostingsByStatuses(clientId, statusList);
         return ResponseEntity.ok(result);
     }
+
 } 

--- a/src/main/java/com/jobmatrix/controller/JobPostingController.java
+++ b/src/main/java/com/jobmatrix/controller/JobPostingController.java
@@ -1,6 +1,6 @@
 package com.jobmatrix.controller;
 
-import com.common.utility.StringToList;
+import com.common.util.EnumUtils;
 import com.jobmatrix.dto.JobPostingDTO;
 import com.jobmatrix.dto.JobPostingUpdateRequest;
 import com.jobmatrix.entity.Category;
@@ -14,11 +14,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/v1/job_postings")
@@ -72,7 +70,7 @@ public class JobPostingController {
             @PathVariable UUID clientId,
             @PathVariable String statuses) {
 
-        List<JobPostingStatus> statusList = StringToList.convertToEnumList(statuses, JobPostingStatus.class);
+        List<JobPostingStatus> statusList = EnumUtils.parseEnumList(statuses, JobPostingStatus.class);
         Map<JobPostingStatus, List<JobPostingDTO>> result = jobPostingService.getJobPostingsByStatuses(clientId, statusList);
         return ResponseEntity.ok(result);
     }

--- a/src/main/java/com/jobmatrix/controller/JobPostingController.java
+++ b/src/main/java/com/jobmatrix/controller/JobPostingController.java
@@ -4,6 +4,7 @@ import com.jobmatrix.dto.JobPostingDTO;
 import com.jobmatrix.dto.JobPostingUpdateRequest;
 import com.jobmatrix.entity.Category;
 import com.jobmatrix.entity.JobPosting;
+import com.jobmatrix.entity.JobPostingStatus;
 import com.jobmatrix.service.JobPostingService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -12,8 +13,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/v1/job_postings")
@@ -60,5 +64,18 @@ public class JobPostingController {
     ){
         JobPosting updatedJobPosting = jobPostingService.updateJobPosting(job_posting_id, jobPostingUpdateRequest);
         return ResponseEntity.ok(updatedJobPosting);
+    }
+
+    @GetMapping("/{clientId}/statuses/{statuses}")
+    public ResponseEntity<Map<JobPostingStatus, List<JobPostingDTO>>> getJobPostingsByStatuses(
+            @PathVariable UUID clientId,
+            @PathVariable String statuses) {
+        // Convert comma separated string to list of JobPostingStatus enum values
+        List<JobPostingStatus> statusList = Arrays.stream(statuses.split(","))
+                .map(String::toUpperCase)
+                .map(JobPostingStatus::valueOf)
+                .collect(Collectors.toList());
+        Map<JobPostingStatus, List<JobPostingDTO>> result = jobPostingService.getJobPostingsByStatuses(clientId, statusList);
+        return ResponseEntity.ok(result);
     }
 } 

--- a/src/main/java/com/jobmatrix/exceptionHandling/GlobalExceptionHandler.java
+++ b/src/main/java/com/jobmatrix/exceptionHandling/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.jobmatrix.exceptionHandling;
 
 import com.common.exceptionHandling.ClientNotFoundException;
+import com.common.exceptionHandling.InvalidEnumValueException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -25,4 +26,8 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
     }
 
+    @ExceptionHandler(InvalidEnumValueException.class)
+    public ResponseEntity<String> handleInvalidEnumValueException(InvalidEnumValueException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
+    }
 }

--- a/src/main/java/com/jobmatrix/repository/JobPostingRepository.java
+++ b/src/main/java/com/jobmatrix/repository/JobPostingRepository.java
@@ -12,4 +12,5 @@ import java.util.UUID;
 public interface JobPostingRepository extends JpaRepository<JobPosting, Long> {
     List<JobPosting> findByJobPostingStatus(JobPostingStatus jobPostingStatus);
     List<JobPosting> findByClientId(UUID clientId);
+    List<JobPosting> findByClientIdAndJobPostingStatus(UUID clientId, JobPostingStatus status);
 } 

--- a/src/main/java/com/jobmatrix/service/JobPostingService.java
+++ b/src/main/java/com/jobmatrix/service/JobPostingService.java
@@ -4,8 +4,10 @@ import com.jobmatrix.dto.JobPostingDTO;
 import com.jobmatrix.dto.JobPostingUpdateRequest;
 import com.jobmatrix.entity.Category;
 import com.jobmatrix.entity.JobPosting;
+import com.jobmatrix.entity.JobPostingStatus;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 public interface JobPostingService {
@@ -15,4 +17,5 @@ public interface JobPostingService {
     List<JobPosting> getJobPostingsByClientId(UUID clientId);
     List<Category> getCategories();
     JobPosting updateJobPosting(Long job_Posting_Id, JobPostingUpdateRequest jobPostingUpdateRequest);
+    Map<JobPostingStatus, List<JobPostingDTO>> getJobPostingsByStatuses(UUID clientId, List<JobPostingStatus> statusList);
 } 

--- a/src/main/java/com/jobmatrix/serviceimpl/JobPostingServiceImpl.java
+++ b/src/main/java/com/jobmatrix/serviceimpl/JobPostingServiceImpl.java
@@ -17,8 +17,7 @@ import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -100,4 +99,18 @@ public class JobPostingServiceImpl implements JobPostingService {
         return jobPostingRepository.save(jobPosting);
     }
 
+    @Override
+    public Map<JobPostingStatus, List<JobPostingDTO>> getJobPostingsByStatuses(UUID clientId, List<JobPostingStatus> statusList) {
+        Map<JobPostingStatus, List<JobPostingDTO>> result = new HashMap<>();
+        for (JobPostingStatus status : statusList) {
+            List<JobPosting> jobPostings = jobPostingRepository.findByClientIdAndJobPostingStatus(clientId, status);
+            List<JobPostingDTO> dtoList = new ArrayList<>();
+            for (JobPosting jobPosting : jobPostings) {
+                JobPostingDTO jobPostingDTO = modelMapper.map(jobPosting, JobPostingDTO.class);
+                dtoList.add(jobPostingDTO);
+            }
+            result.put(status, dtoList);
+        }
+        return result;
+    }
 }

--- a/src/test/java/com/jobmatrix/controller/JobPostingControllerTest.java
+++ b/src/test/java/com/jobmatrix/controller/JobPostingControllerTest.java
@@ -3,10 +3,7 @@ package com.jobmatrix.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jobmatrix.dto.JobPostingDTO;
 import com.jobmatrix.dto.JobPostingUpdateRequest;
-import com.jobmatrix.entity.BudgetType;
-import com.jobmatrix.entity.ExperienceLevel;
-import com.jobmatrix.entity.Category;
-import com.jobmatrix.entity.JobPosting;
+import com.jobmatrix.entity.*;
 import com.jobmatrix.service.JobPostingService;
 import com.jobmatrix.test_utils.factory.JobPostingTestDataFactory;
 import org.junit.jupiter.api.Test;
@@ -19,8 +16,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 
 @WebMvcTest(JobPostingController.class)
 public class JobPostingControllerTest {
@@ -182,5 +178,53 @@ public class JobPostingControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.updatedAt").exists());
 
         Mockito.verify(jobPostingService).updateJobPosting(Mockito.eq(jobPostingId), Mockito.any(JobPostingUpdateRequest.class));
+    }
+
+    @Test
+    void testGetJobPostingsByStatuses() throws Exception {
+        UUID clientId = UUID.randomUUID();
+        String statuses = "DRAFT,OPEN";
+
+        JobPostingDTO draftJobDTO = JobPostingTestDataFactory.createJobPostingDTO(clientId);
+        JobPostingDTO openJobDTO = JobPostingTestDataFactory.createJobPostingDTO(clientId);
+        openJobDTO.setTitle("Open Job");
+
+        Map<JobPostingStatus, List<JobPostingDTO>> mockResult = Map.of(
+                JobPostingStatus.DRAFT, List.of(draftJobDTO),
+                JobPostingStatus.OPEN, List.of(openJobDTO)
+        );
+
+        Mockito.when(jobPostingService.getJobPostingsByStatuses(
+                Mockito.eq(clientId),
+                Mockito.argThat(list ->
+                        list.containsAll(Arrays.asList(JobPostingStatus.DRAFT, JobPostingStatus.OPEN))
+                )
+        )).thenReturn(mockResult);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/job_postings/{clientId}/statuses/{statuses}",
+                        clientId, statuses))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.DRAFT").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.OPEN").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.DRAFT.length()").value(1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.OPEN.length()").value(1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.DRAFT[0].title").value(draftJobDTO.getTitle()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.OPEN[0].title").value("Open Job"));
+    }
+
+    @Test
+    void testGetJobPostingsByStatuses_EmptyResult() throws Exception {
+        UUID clientId = UUID.randomUUID();
+        String statuses = "DRAFT,OPEN";
+
+        Mockito.when(jobPostingService.getJobPostingsByStatuses(
+                Mockito.eq(clientId),
+                Mockito.anyList()
+        )).thenReturn(new HashMap<>());
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/job_postings/{clientId}/statuses/{statuses}",
+                        clientId, statuses))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$").isEmpty());
     }
 }

--- a/src/test/java/com/jobmatrix/controller/JobPostingControllerTest.java
+++ b/src/test/java/com/jobmatrix/controller/JobPostingControllerTest.java
@@ -227,4 +227,29 @@ public class JobPostingControllerTest {
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$").isEmpty());
     }
+
+    @Test
+    void testGetJobPostingsByStatuses_EmptyStatuses() throws Exception {
+        UUID clientId = UUID.randomUUID();
+        String statuses = " ";
+        Mockito.when(jobPostingService.getJobPostingsByStatuses(
+                Mockito.eq(clientId),
+                Mockito.eq(Collections.emptyList())
+        )).thenReturn(Collections.emptyMap());
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/job_postings/{clientId}/statuses/{statuses}",
+                        clientId, statuses))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().json("{}"));
+    }
+
+    @Test
+    void testGetJobPostingsByStatuses_InvalidEnumValue() throws Exception {
+        UUID clientId = UUID.randomUUID();
+        String statuses = "DRAFT,INVALID_STATUS";
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/job_postings/{clientId}/statuses/{statuses}",
+                        clientId, statuses))
+                .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                .andExpect(MockMvcResultMatchers.content().string("Invalid value 'INVALID_STATUS' for enum: JobPostingStatus"));
+    }
 }

--- a/src/test/java/com/jobmatrix/service/JobPostingServiceImplTest.java
+++ b/src/test/java/com/jobmatrix/service/JobPostingServiceImplTest.java
@@ -27,6 +27,7 @@ import org.modelmapper.ModelMapper;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -373,4 +374,74 @@ public class JobPostingServiceImplTest {
         verify(jobPostingRepository, never()).save(any());
     }
 
+    @Test
+    void getJobPostingsByStatuses_Success() {
+        UUID clientId = UUID.randomUUID();
+        List<JobPostingStatus> statusList = List.of(JobPostingStatus.DRAFT, JobPostingStatus.OPEN);
+
+        JobPosting draftPosting = JobPostingTestDataFactory.createJobPostingEntity(clientId);
+        draftPosting.setJobPostingStatus(JobPostingStatus.DRAFT);
+
+        JobPosting openPosting = JobPostingTestDataFactory.createJobPostingEntity(clientId);
+        openPosting.setJobPostingStatus(JobPostingStatus.OPEN);
+
+        when(jobPostingRepository.findByClientIdAndJobPostingStatus(clientId, JobPostingStatus.DRAFT))
+                .thenReturn(List.of(draftPosting));
+        when(jobPostingRepository.findByClientIdAndJobPostingStatus(clientId, JobPostingStatus.OPEN))
+                .thenReturn(List.of(openPosting));
+
+        JobPostingDTO draftDTO = JobPostingTestDataFactory.createJobPostingDTO(clientId);
+        JobPostingDTO openDTO = JobPostingTestDataFactory.createJobPostingDTO(clientId);
+        when(modelMapper.map(draftPosting, JobPostingDTO.class)).thenReturn(draftDTO);
+        when(modelMapper.map(openPosting, JobPostingDTO.class)).thenReturn(openDTO);
+
+        Map<JobPostingStatus, List<JobPostingDTO>> result = jobPostingService.getJobPostingsByStatuses(clientId, statusList);
+
+        assertNotNull(result);
+        assertEquals(2, result.size());
+        assertTrue(result.containsKey(JobPostingStatus.DRAFT));
+        assertTrue(result.containsKey(JobPostingStatus.OPEN));
+        assertEquals(1, result.get(JobPostingStatus.DRAFT).size());
+        assertEquals(1, result.get(JobPostingStatus.OPEN).size());
+
+        verify(jobPostingRepository).findByClientIdAndJobPostingStatus(clientId, JobPostingStatus.DRAFT);
+        verify(jobPostingRepository).findByClientIdAndJobPostingStatus(clientId, JobPostingStatus.OPEN);
+        verify(modelMapper, times(2)).map(any(JobPosting.class), eq(JobPostingDTO.class));
+    }
+
+    @Test
+    void getJobPostingsByStatuses_EmptyResults() {
+        UUID clientId = UUID.randomUUID();
+        List<JobPostingStatus> statusList = List.of(JobPostingStatus.DRAFT, JobPostingStatus.OPEN);
+
+        when(jobPostingRepository.findByClientIdAndJobPostingStatus(eq(clientId), any(JobPostingStatus.class)))
+                .thenReturn(List.of());
+
+        Map<JobPostingStatus, List<JobPostingDTO>> result = jobPostingService.getJobPostingsByStatuses(clientId, statusList);
+
+        assertNotNull(result);
+        assertEquals(2, result.size());
+        assertTrue(result.containsKey(JobPostingStatus.DRAFT));
+        assertTrue(result.containsKey(JobPostingStatus.OPEN));
+        assertTrue(result.get(JobPostingStatus.DRAFT).isEmpty());
+        assertTrue(result.get(JobPostingStatus.OPEN).isEmpty());
+
+        verify(jobPostingRepository, times(2))
+                .findByClientIdAndJobPostingStatus(eq(clientId), any(JobPostingStatus.class));
+        verify(modelMapper, never()).map(any(), any());
+    }
+
+    @Test
+    void getJobPostingsByStatuses_WithEmptyStatusList() {
+        UUID clientId = UUID.randomUUID();
+        List<JobPostingStatus> statusList = List.of();
+
+        Map<JobPostingStatus, List<JobPostingDTO>> result = jobPostingService.getJobPostingsByStatuses(clientId, statusList);
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+
+        verify(jobPostingRepository, never()).findByClientIdAndJobPostingStatus(any(), any());
+        verify(modelMapper, never()).map(any(), any());
+    }
 }


### PR DESCRIPTION
Added a new endpoint to retrieve job postings filtered by client ID and multiple job posting statuses. This enhancement allows clients to fetch their job postings grouped by different statuses.

- **Endpoint**:  `GET /api/v1/job_postings/{clientId}/statuses/{statuses}`
- **Path Parameters**:
  - `clientId`: UUID of the client
  - `statuses`: Comma-separated list of JobPostingStatus values (e.g., "DRAFT,OPEN")
- **Response**: Map of JobPostingStatus to list of JobPostingDTO objects:
`{
  "DRAFT": [job_1_object, job_2_object],
  "IN_PROGRESS" : [job_3_object...]
 ....
}`