### PR TITLE
JMK_100: Read status from frontend for job post

### DIFF
--- a/src/main/java/com/jobmatrix/dto/JobPostingDTO.java
+++ b/src/main/java/com/jobmatrix/dto/JobPostingDTO.java
@@ -2,6 +2,7 @@ package com.jobmatrix.dto;
 
 import com.jobmatrix.entity.BudgetType;
 import com.jobmatrix.entity.ExperienceLevel;
+import com.jobmatrix.entity.JobPostingStatus;
 import com.jobmatrix.entity.ProjectDuration;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -44,4 +45,6 @@ public class JobPostingDTO {
 
     @NotNull(message = "category_id cannot be null.")
     private Long categoryId;
+
+    private JobPostingStatus jobPostingStatus;
 }

--- a/src/main/java/com/jobmatrix/serviceimpl/JobPostingServiceImpl.java
+++ b/src/main/java/com/jobmatrix/serviceimpl/JobPostingServiceImpl.java
@@ -36,8 +36,10 @@ public class JobPostingServiceImpl implements JobPostingService {
         JobPosting jobPosting = modelMapper.map(jobPostingDTO, JobPosting.class);
         // Ensure it's treated as a new entity
         jobPosting.setJobPostingId(null);
-        // Set default job posting status
-        jobPosting.setJobPostingStatus(JobPostingStatus.DRAFT);
+        // Set default job posting status if it is null
+        if (jobPostingDTO.getJobPostingStatus() == null) {
+            jobPosting.setJobPostingStatus(JobPostingStatus.IN_REVIEW);
+        }
         // Fetch category and set it
         Category category = categoryRepository.findById(jobPostingDTO.getCategoryId())
                 .orElseThrow(() -> new CategoryNotFoundException(jobPostingDTO.getCategoryId()));

--- a/src/test/java/com/jobmatrix/service/JobPostingServiceImplTest.java
+++ b/src/test/java/com/jobmatrix/service/JobPostingServiceImplTest.java
@@ -79,6 +79,7 @@ public class JobPostingServiceImplTest {
         jobPosting.setHourlyMaxRate(jobPostingDTO.getHourlyMaxRate());
         jobPosting.setProjectDuration(jobPostingDTO.getProjectDuration());
         jobPosting.setExperienceLevel(jobPostingDTO.getExperienceLevel());
+        jobPosting.setJobPostingStatus(JobPostingStatus.OPEN);
 
         when(categoryRepository.findById(jobPostingDTO.getCategoryId())).thenReturn(Optional.of(category));
         when(modelMapper.map(jobPostingDTO, JobPosting.class)).thenReturn(jobPosting);
@@ -102,7 +103,7 @@ public class JobPostingServiceImplTest {
         assertEquals(jobPostingDTO.getHourlyMaxRate(), result.getHourlyMaxRate());
         assertEquals(jobPostingDTO.getProjectDuration(), result.getProjectDuration());
         assertEquals(jobPostingDTO.getExperienceLevel(), result.getExperienceLevel());
-        assertEquals(JobPostingStatus.DRAFT, result.getJobPostingStatus());
+        assertEquals(JobPostingStatus.OPEN, result.getJobPostingStatus());
         assertEquals(category, result.getCategory());
         assertNotNull(result.getCreatedAt());
         assertNotNull(result.getUpdatedAt());
@@ -111,6 +112,31 @@ public class JobPostingServiceImplTest {
         verify(categoryRepository, times(1)).findById(jobPostingDTO.getCategoryId());
         verify(jobPostingRepository, times(1)).save(any(JobPosting.class));
         verify(modelMapper, times(1)).map(jobPostingDTO, JobPosting.class);
+    }
+
+    @Test
+    public void testCreateJobPosting_NullStatus() {
+        JobPosting jobPosting = new JobPosting();
+        jobPosting.setTitle(jobPostingDTO.getTitle());
+        jobPosting.setDescription(jobPostingDTO.getDescription());
+        jobPosting.setBudgetType(jobPostingDTO.getBudgetType());
+        jobPosting.setHourlyMinRate(jobPostingDTO.getHourlyMinRate());
+        jobPosting.setHourlyMaxRate(jobPostingDTO.getHourlyMaxRate());
+        jobPosting.setProjectDuration(jobPostingDTO.getProjectDuration());
+        jobPosting.setExperienceLevel(jobPostingDTO.getExperienceLevel());
+        jobPostingDTO.setJobPostingStatus(null);
+        when(categoryRepository.findById(jobPostingDTO.getCategoryId())).thenReturn(Optional.of(category));
+        when(modelMapper.map(jobPostingDTO, JobPosting.class)).thenReturn(jobPosting);
+        when(jobPostingRepository.save(any(JobPosting.class))).thenAnswer(invocation -> {
+            JobPosting savedJob = invocation.getArgument(0);
+            savedJob.setJobPostingId(1L);
+            savedJob.setCreatedAt(LocalDateTime.now());
+            savedJob.setUpdatedAt(LocalDateTime.now());
+            return savedJob;
+        });
+        JobPosting result = jobPostingService.createJobPosting(jobPostingDTO);
+        assertNotNull(result);
+        assertEquals(JobPostingStatus.IN_REVIEW, result.getJobPostingStatus());
     }
 
 

--- a/src/test/java/com/jobmatrix/test_utils/factory/JobPostingTestDataFactory.java
+++ b/src/test/java/com/jobmatrix/test_utils/factory/JobPostingTestDataFactory.java
@@ -30,6 +30,7 @@ public class JobPostingTestDataFactory {
                 .projectDuration(PROJECT_DURATION)
                 .experienceLevel(EXPERIENCE_LEVEL)
                 .categoryId(CATEGORY_ID)
+                .jobPostingStatus(STATUS)
                 .build();
     }
 


### PR DESCRIPTION
Added jobPostingStatus to JobPostingDTO to accept status from frontend. If status is not specified from frontend i.e. its null then it is set to default - `IN_REVIEW`
[JMK_100](https://punjabskillsbank.atlassian.net/browse/JMK-100)